### PR TITLE
Fixes access token export for k8s secret

### DIFF
--- a/process/score_download.nf
+++ b/process/score_download.nf
@@ -41,7 +41,7 @@ process scoreDownload {
     export STORAGE_URL=${params.score_url}
     export TRANSPORT_PARALLEL=${params.cpus}
     export TRANSPORT_MEMORY=${params.transport_mem}
-    export ACCESSTOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export ACCESSTOKEN=`cat /tmp/${workflow.runName}/secret`
     
     score-client download --analysis-id ${analysis_id} --study-id ${study_id} --output-dir ./out 
     """

--- a/process/score_upload.nf
+++ b/process/score_upload.nf
@@ -37,7 +37,7 @@ process scoreUpload {
     export STORAGE_URL=${params.score_url}
     export TRANSPORT_PARALLEL=${params.cpus}
     export TRANSPORT_MEMORY=${params.transport_mem}
-    export ACCESSTOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export ACCESSTOKEN=`cat /tmp/${workflow.runName}/secret`
     
     score-client upload --manifest ${manifest}
     """

--- a/process/song_get_analysis.nf
+++ b/process/song_get_analysis.nf
@@ -33,7 +33,7 @@ process songGetAnalysis {
     """
     export CLIENT_SERVER_URL=${params.song_url}
     export CLIENT_STUDY_ID=${study_id}
-    export CLIENT_ACCESS_TOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export CLIENT_ACCESS_TOKEN=`cat /tmp/${workflow.runName}/secret`
 
     sing search -a ${analysis_id} > ${analysis_id}.analysis.json
     """

--- a/process/song_manifest.nf
+++ b/process/song_manifest.nf
@@ -33,7 +33,7 @@ process songManifest {
     """
     export CLIENT_SERVER_URL=${params.song_url}
     export CLIENT_STUDY_ID=${study_id}
-    export CLIENT_ACCESS_TOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export CLIENT_ACCESS_TOKEN=`cat /tmp/${workflow.runName}/secret`
 
     sing manifest -a ${analysis_id} -d . -f ./out/manifest.txt
     """

--- a/process/song_publish.nf
+++ b/process/song_publish.nf
@@ -32,7 +32,7 @@ process songPublish {
     """
     export CLIENT_SERVER_URL=${params.song_url}
     export CLIENT_STUDY_ID=${study_id}
-    export CLIENT_ACCESS_TOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export CLIENT_ACCESS_TOKEN=`cat /tmp/${workflow.runName}/secret`
 
     sing publish -a  ${analysis_id}
     """

--- a/process/song_submit.nf
+++ b/process/song_submit.nf
@@ -33,7 +33,7 @@ process songSubmit {
     """
     export CLIENT_SERVER_URL=${params.song_url}
     export CLIENT_STUDY_ID=${study_id}
-    export CLIENT_ACCESS_TOKEN=`base64 -d /tmp/${workflow.runName}/secret`
+    export CLIENT_ACCESS_TOKEN=`cat /tmp/${workflow.runName}/secret`
 
     set -euxo pipefail
     sing submit -f ${payload} | jq -er .analysisId | tr -d '\\n'


### PR DESCRIPTION
Fixes a bug I found in testing. 

I am using Opaque secrets in kubernetes and putting the secret information as part of the secret data and not string data. Credentials that are part of a secrets data are enforced base64 for storage and are automatically decoded from base64 when mounted in the pod. My original PoC was using string data rather than data which is why I attempted it this way first. 

Source: https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually